### PR TITLE
Use Environment variable to specify DOT_PATH

### DIFF
--- a/Doxyfile_en.doxy
+++ b/Doxyfile_en.doxy
@@ -2337,7 +2337,7 @@ INTERACTIVE_SVG        = NO
 # found. If left blank, it is assumed the dot tool can be found in the path.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_PATH               = "C:/Program Files/Graphviz 2.38/bin/"
+DOT_PATH               = $(GRAPHVIZ_PATH)
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that
 # contain dot files that are included in the documentation (see the \dotfile

--- a/Doxyfile_ja.doxy
+++ b/Doxyfile_ja.doxy
@@ -2337,7 +2337,7 @@ INTERACTIVE_SVG        = NO
 # found. If left blank, it is assumed the dot tool can be found in the path.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_PATH               = "C:/Program Files/Graphviz 2.38/bin/"
+DOT_PATH               = $(GRAPHVIZ_PATH)
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that
 # contain dot files that are included in the documentation (see the \dotfile


### PR DESCRIPTION
doxygenのconfigで``DOT_PATH``の指定があり、Graphvizのbinフォルダのパスを指定するが、これを直接書くのではなく、環境変数``GRAPHVIZ_PATH``を参照するように変更することを提案する。

理由
人によって各種ツールのインストール場所は違うため。
空欄にするのはPATHが汚れるので賛成しない