### PR TITLE
use forward declaration instead of disabling COM(define CINTERFACE)

### DIFF
--- a/dxlibex/basic_types/tchar.hpp
+++ b/dxlibex/basic_types/tchar.hpp
@@ -8,11 +8,11 @@
 #ifndef DXLE_INC_BASIC_TYPES_TCHAR_HPP_
 #define DXLE_INC_BASIC_TYPES_TCHAR_HPP_
 
-#if !defined(CINTERFACE) && defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
+#if defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
 //To avoid compile error
 //C:\Program Files (x86)\Windows Kits\8.1\Include\um\combaseapi.h(229,21): error : unknown type name 'IUnknown'
 //          static_cast<IUnknown*>(*pp);    // make sure everyone derives from IUnknown
-#define CINTERFACE
+struct IUnknown;
 #endif
 #if defined(__c2__)
 //Visual Studio 2015 Update 1 Clang with Microsoft CodeGen(clang 3.7)にはtchar.hまわりにバグあり、include順をいじるな

--- a/dxlibex/color.hpp
+++ b/dxlibex/color.hpp
@@ -9,11 +9,11 @@
 #define DXLE_INC_COLOR_HPP_
 
 #include "dxlibex/config/no_min_max.h"
-#if !defined(CINTERFACE) && defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
+#if defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
 //To avoid compile error
 //C:\Program Files (x86)\Windows Kits\8.1\Include\um\combaseapi.h(229,21): error : unknown type name 'IUnknown'
 //          static_cast<IUnknown*>(*pp);    // make sure everyone derives from IUnknown
-#define CINTERFACE
+struct IUnknown;
 #endif
 #include "DxLib.h"
 #include "dxlibex/config/defines.h"

--- a/dxlibex/structs.h
+++ b/dxlibex/structs.h
@@ -8,11 +8,11 @@
 #ifndef DXLE_INC_STRUCTS_H_
 #define DXLE_INC_STRUCTS_H_
 #include "dxlibex/config/no_min_max.h"
-#if !defined(CINTERFACE) && defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
+#if defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
 //To avoid compile error
 //C:\Program Files (x86)\Windows Kits\8.1\Include\um\combaseapi.h(229,21): error : unknown type name 'IUnknown'
 //          static_cast<IUnknown*>(*pp);    // make sure everyone derives from IUnknown
-#define CINTERFACE
+struct IUnknown;
 #endif
 #include "DxLib.h"
 

--- a/dxlibex/texture/texture2d.hpp
+++ b/dxlibex/texture/texture2d.hpp
@@ -9,11 +9,11 @@
 #define DXLE_INC_TEXTURE_TEXTURE2D_HPP_
 
 #include "dxlibex/config/no_min_max.h"
-#if !defined(CINTERFACE) && defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
+#if defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
 //To avoid compile error
 //C:\Program Files (x86)\Windows Kits\8.1\Include\um\combaseapi.h(229,21): error : unknown type name 'IUnknown'
 //          static_cast<IUnknown*>(*pp);    // make sure everyone derives from IUnknown
-#define CINTERFACE
+struct IUnknown;
 #endif
 #include "DxLib.h"
 #include <mutex>

--- a/dxlibex/texture/texture2d/prototype2d.hpp
+++ b/dxlibex/texture/texture2d/prototype2d.hpp
@@ -9,11 +9,11 @@
 #define DXLE_INC_TEXTURE_TEXTURE2D_PROTOTYPE2D_HPP_
 
 #include "dxlibex/config/no_min_max.h"
-#if !defined(CINTERFACE) && defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
+#if defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
 //To avoid compile error
 //C:\Program Files (x86)\Windows Kits\8.1\Include\um\combaseapi.h(229,21): error : unknown type name 'IUnknown'
 //          static_cast<IUnknown*>(*pp);    // make sure everyone derives from IUnknown
-#define CINTERFACE
+struct IUnknown;
 #endif
 #include "DxLib.h"
 #include "dxlibex/basic_types.hpp"

--- a/dxlibex/texture/texture2d/texture2d.hpp
+++ b/dxlibex/texture/texture2d/texture2d.hpp
@@ -9,11 +9,11 @@
 #define DXLE_INC_TEXTURE_TEXTURE2D_TEXTURE2D_HPP_
 
 #include "dxlibex/config/no_min_max.h"
-#if !defined(CINTERFACE) && defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
+#if defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
 //To avoid compile error
 //C:\Program Files (x86)\Windows Kits\8.1\Include\um\combaseapi.h(229,21): error : unknown type name 'IUnknown'
 //          static_cast<IUnknown*>(*pp);    // make sure everyone derives from IUnknown
-#define CINTERFACE
+struct IUnknown;
 #endif
 #include "DxLib.h"
 #include <cstdint>

--- a/dxlibex/thread.hpp
+++ b/dxlibex/thread.hpp
@@ -9,11 +9,11 @@
 #define DXLE_INC_THREAD_HPP_
 
 #include "dxlibex/config/no_min_max.h"
-#if !defined(CINTERFACE) && defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
+#if defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
 //To avoid compile error
 //C:\Program Files (x86)\Windows Kits\8.1\Include\um\combaseapi.h(229,21): error : unknown type name 'IUnknown'
 //          static_cast<IUnknown*>(*pp);    // make sure everyone derives from IUnknown
-#define CINTERFACE
+struct IUnknown;
 #endif
 #include <mutex>
 #include "DxLib.h"

--- a/dxlibex/time.hpp
+++ b/dxlibex/time.hpp
@@ -9,11 +9,11 @@
 #define DXLE_INC_TIME_HPP_
 
 #include "dxlibex/config/no_min_max.h"
-#if !defined(CINTERFACE) && defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
+#if defined(__c2__) &&  __clang_major__ == 3 && __clang_minor__ == 8
 //To avoid compile error
 //C:\Program Files (x86)\Windows Kits\8.1\Include\um\combaseapi.h(229,21): error : unknown type name 'IUnknown'
 //          static_cast<IUnknown*>(*pp);    // make sure everyone derives from IUnknown
-#define CINTERFACE
+struct IUnknown;
 #endif
 #include <vector>
 #include <chrono>


### PR DESCRIPTION
Clang with Microsoft CodeGen(July 2016) produce 

```
error : unknown type name 'IUnknown'
```

such error.
I don't know when the bug was fixed. However, for newer version of Clang with Microsoft Codegen, use forward declaration to avoid that.

ref: #84

- [ ] #84 をclose